### PR TITLE
Fixes creative tab item leak

### DIFF
--- a/src/main/java/com/elytradev/correlated/item/ItemDrive.java
+++ b/src/main/java/com/elytradev/correlated/item/ItemDrive.java
@@ -168,8 +168,10 @@ public class ItemDrive extends Item {
 
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
-		for (int i = 0; i < tierSizes.length; i++) {
-			subItems.add(new ItemStack(this, 1, i));
+		if (isInCreativeTab(tab)) {
+			for (int i = 0; i < tierSizes.length; i++) {
+				subItems.add(new ItemStack(this, 1, i));
+			}
 		}
 	}
 

--- a/src/main/java/com/elytradev/correlated/item/ItemKeycard.java
+++ b/src/main/java/com/elytradev/correlated/item/ItemKeycard.java
@@ -40,8 +40,10 @@ public class ItemKeycard extends Item {
 
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
-		for (int i = 0; i < colors.length; i++) {
-			subItems.add(new ItemStack(this, 1, i));
+		if (isInCreativeTab(tab)) {
+			for (int i = 0; i < colors.length; i++) {
+				subItems.add(new ItemStack(this, 1, i));
+			}
 		}
 	}
 	

--- a/src/main/java/com/elytradev/correlated/item/ItemMemory.java
+++ b/src/main/java/com/elytradev/correlated/item/ItemMemory.java
@@ -35,8 +35,10 @@ public class ItemMemory extends Item {
 
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
-		for (int i = 0; i < tierSizes.length; i++) {
-			subItems.add(new ItemStack(this, 1, i));
+		if (isInCreativeTab(tab)) {
+			for (int i = 0; i < tierSizes.length; i++) {
+				subItems.add(new ItemStack(this, 1, i));
+			}
 		}
 	}
 

--- a/src/main/java/com/elytradev/correlated/item/ItemMisc.java
+++ b/src/main/java/com/elytradev/correlated/item/ItemMisc.java
@@ -102,9 +102,11 @@ public class ItemMisc extends Item {
 
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
-		for (int i = 0; i < items.length; i++) {
-			if (i == 9) continue;
-			subItems.add(new ItemStack(this, 1, i));
+		if (isInCreativeTab(tab)) {
+			for (int i = 0; i < items.length; i++) {
+				if (i == 9) continue;
+				subItems.add(new ItemStack(this, 1, i));
+			}
 		}
 	}
 

--- a/src/main/java/com/elytradev/correlated/item/ItemModule.java
+++ b/src/main/java/com/elytradev/correlated/item/ItemModule.java
@@ -38,8 +38,10 @@ public class ItemModule extends Item {
 
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems) {
-		for (int i = 0; i < types.length; i++) {
-			subItems.add(new ItemStack(this, 1, i));
+		if (isInCreativeTab(tab)) {
+			for (int i = 0; i < types.length; i++) {
+				subItems.add(new ItemStack(this, 1, i));
+			}
 		}
 	}
 


### PR DESCRIPTION
Correlated Items are visible in every tab on 1.12. To fix that, you need to check ´isInCreativeTab´.

See https://www.reddit.com/r/feedthebeast/comments/6h9z7f/psa_the_creativetab_leak_glitch/